### PR TITLE
Features/dns lookup

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -110,7 +110,7 @@ bazel_dep(
 
 bazel_dep(
     name = "liburing",
-    version = "2.5",
+    version = "2.10",
 )
 
 ########################################

--- a/experimental/reactor/BUILD
+++ b/experimental/reactor/BUILD
@@ -91,3 +91,10 @@ cc_test(
     ],
     size = "small",
 )
+
+cc_binary(
+    name = "lookup_address",
+    visibility = ["//visibility:public"],
+    srcs = ["lookup_address.cpp"],
+    deps = [":reactor"],
+)

--- a/experimental/reactor/BUILD
+++ b/experimental/reactor/BUILD
@@ -71,13 +71,13 @@ cc_library(
         "reactor.h"
     ],
     deps = [
+        ":control_blocks",
+        ":uring",
         # TODO(bd) figure out how to make boost.asio work with shadow
         # stacks or try a different thread pool implementation
         # "@boost.asio",
         "@bs_thread-pool//:thread_pool",
         "@dp_thread-pool//:thread_pool",
-        ":control_blocks",
-        ":uring",
     ],
 )
 

--- a/experimental/reactor/fiber.cpp
+++ b/experimental/reactor/fiber.cpp
@@ -49,9 +49,7 @@ Fiber::Fiber(FiberId id, Reactor& reactor)
 
 void Fiber::yield() { reactor_->yieldFbr(); }
 
-void Fiber::execute(std::function<void(void)> fcn) {
-  reactor_->execute(std::move(fcn));
-}
+void Fiber::execute(Fiber::WorkerFcn fcn) { reactor_->execute(std::move(fcn)); }
 
 FileDescriptor Fiber::openFile(const std::filesystem::path& file_path,
                                const FileOpenFlags flags,
@@ -149,6 +147,10 @@ uring::Event Fiber::getEvent(const std::string_view op) {
 
 void Fiber::validateEvent(const std::string_view op) {
   const auto _ = getEvent(op);
+}
+
+Fiber::WorkerFcn Fiber::makeFbrNotifier(FiberId id) {
+  return [id = id, reactor_ptr = reactor_]() { reactor_ptr->notifyFbr(id); };
 }
 
 } // namespace jmg

--- a/experimental/reactor/fiber.h
+++ b/experimental/reactor/fiber.h
@@ -212,8 +212,8 @@ public:
    * write data to an open file descriptor
    */
   template<WritableDescriptorT T>
-  void write(T fd, BufferView data) {
-    if (data.empty()) { return; }
+  size_t write(T fd, BufferView data) {
+    if (data.empty()) { return 0; }
     auto iov = iov_from(data);
     // set the user data to the fiber ID so the completion event gets routed
     // back to this thread
@@ -227,7 +227,10 @@ public:
 
     ////////////////////
     // return from scheduler
-    validateEvent("write data");
+    const auto event = getEvent("write data");
+    const auto& cqe = *(event);
+    return static_cast<size_t>(cqe.res);
+  }
   }
 
 private:

--- a/experimental/reactor/fiber.h
+++ b/experimental/reactor/fiber.h
@@ -116,7 +116,7 @@ public:
 
   // TODO(bd) add support for std::move_only_function?
   /**
-   * send a task to a thread pool associated with the reactor without
+   * send a task to the thread pool associated with the reactor without
    * expecting a result
    */
   void execute(WorkerFcn fcn);
@@ -230,8 +230,6 @@ private:
   friend class Reactor;
 
   Fiber(FiberId id, Reactor& reactor);
-
-  size_t read(int fd, BufferProxy buf);
 
   /**
    * non-blocking close of generic (file) descriptor

--- a/experimental/reactor/fiber.h
+++ b/experimental/reactor/fiber.h
@@ -124,6 +124,10 @@ public:
   /**
    * send a computation task to the thread pool associated with the
    * reactor and return the resulting value back to the fiber
+   *
+   * NOTE: this function will automatically capture any exceptions
+   * thrown within the body of its compute function and propagate them
+   * to the caller
    */
   template<typename Fcn, typename... Args>
     requires std::invocable<Fcn, Args...>

--- a/experimental/reactor/fiber.h
+++ b/experimental/reactor/fiber.h
@@ -182,6 +182,29 @@ public:
    */
   void connectTo(SocketDescriptor sd, const IpEndpoint& tgt_endpoint);
 
+  /**
+   * read data from a socket
+   *
+   * TODO(bd) create a safe type for flags
+   */
+  size_t recvFrom(SocketDescriptor fd, BufferProxy buf, int flags);
+
+  /**
+   * set options for a socket
+   *
+   * TODO(bd) support multiple options in a single command
+   *
+   * TODO(bd) create safe types for level and opt_id
+   *
+   * TODO(bd) create an owning type for the combination of level,
+   * opt_id, opt_val and opt_sz
+   */
+  void setSocketOption(SocketDescriptor fd,
+                       int level,
+                       int opt_id,
+                       const void* opt_val,
+                       size_t opt_sz);
+
   ////////////////////
   // reading and writing data
 
@@ -230,7 +253,6 @@ public:
     const auto event = getEvent("write data");
     const auto& cqe = *(event);
     return static_cast<size_t>(cqe.res);
-  }
   }
 
 private:

--- a/experimental/reactor/lookup_address.cpp
+++ b/experimental/reactor/lookup_address.cpp
@@ -1,0 +1,105 @@
+/** -*- mode: c++ -*-
+ *
+ * Copyright (C) 2026 Brian Davis
+ * All Rights Reserved
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: Brian Davis <brian8702@sbcglobal.net>
+ *
+ */
+
+/**
+ * Simple command line program that takes a hostname argument and logs
+ * the list of IP endpoints associated with it.
+ *
+ * Mostly intended as a testbed for DNS lookup support in the reactor.
+ */
+
+#include <chrono>
+#include <iostream>
+
+#include "jmg/cmdline.h"
+#include "jmg/future.h"
+#include "jmg/system.h"
+
+#include "reactor.h"
+
+using namespace jmg;
+using namespace std;
+using namespace std::chrono_literals;
+
+using Signaller = Promise<void>;
+using SignallerPtr = shared_ptr<Signaller>;
+
+namespace
+{
+auto makeSignaller() {
+  auto signaller = Signaller();
+  auto rcvr = signaller.get_future();
+  return make_tuple(std::move(signaller), std::move(rcvr));
+}
+} // namespace
+
+using Hostname =
+  PosnParam<string, "hostname", "host name to look up address for">;
+using CmdLine = CmdLineArgs<Hostname>;
+
+int main(const int argc, const char** argv) {
+  try {
+    // process arguments
+    const auto cmdline = CmdLine(argc, argv);
+    const auto hostname = get<Hostname>(cmdline);
+
+    // start reactor
+    Reactor reactor;
+    auto [reactor_start_signal, reactor_start_rcvr] = makeSignaller();
+    auto reactor_worker = thread([&] {
+      blockAllSignals();
+      try {
+        reactor_start_signal.set_value();
+        reactor.start();
+      }
+      JMG_SINK_ALL_EXCEPTIONS("reactor worker thread top level")
+    });
+    const auto awaitShutdown = Cleanup([&] { reactor_worker.join(); });
+    reactor_start_rcvr.get(2s, "reactor start signal");
+
+    {
+      // execute query
+      const auto terminator = Cleanup([&] { reactor.shutdown(); });
+      const auto endpoints =
+        reactor.compute([&](Fiber& fbr) mutable -> Fiber::IpEndpoints {
+          return fbr.lookupNetworkEndpoints(hostname);
+        });
+      cout << "IP endpoints for host [" << hostname << "]:\n";
+      for (const auto& endpoint : endpoints) {
+        cout << " - " << static_cast<string>(from(endpoint.addr())) << "\n";
+      }
+    }
+
+    return EXIT_SUCCESS;
+  }
+  JMG_SINK_ALL_EXCEPTIONS("main top level")
+}

--- a/experimental/reactor/lookup_address.cpp
+++ b/experimental/reactor/lookup_address.cpp
@@ -111,5 +111,11 @@ int main(const int argc, const char** argv) {
 
     return EXIT_SUCCESS;
   }
+  catch (const CmdLineError& e) {
+    // NOTE: logging e.what() directly will log the error and usage
+    // messages without extra exception-specific verbiage
+    cout << e.what() << endl;
+  }
   JMG_SINK_ALL_EXCEPTIONS("main top level")
+  return EXIT_FAILURE;
 }

--- a/experimental/reactor/misc/reactor_echo_client.cpp
+++ b/experimental/reactor/misc/reactor_echo_client.cpp
@@ -82,7 +82,7 @@ int main(const int argc, const char** argv) {
     });
 
     Promise<string> work_product;
-    reactor.post([&](Fiber& fbr) {
+    reactor.execute([&](Fiber& fbr) {
       try {
         // open socket
         const auto sd = fbr.openSocket(SocketTypes::kTcp);

--- a/experimental/reactor/reactor.cpp
+++ b/experimental/reactor/reactor.cpp
@@ -72,7 +72,7 @@ concept ReactorFcnT = jmg::SameAsDecayedT<jmg::Reactor::WorkerFcn, T>
 void workerTrampoline(const intptr_t lambda_ptr_val) {
   try {
     // NOTE: Google told me to do this, it's not my fault
-    auto* lambda_ptr = reinterpret_cast<std::function<void()>*>(lambda_ptr_val);
+    auto* lambda_ptr = reinterpret_cast<function<void()>*>(lambda_ptr_val);
     JMG_ENFORCE(jmg::pred(lambda_ptr), "unable to trampoline to simple worker");
     (*lambda_ptr)();
   }
@@ -251,7 +251,7 @@ void Reactor::post(FiberFcn&& fcn) {
   lambda_ptr.release();
 }
 
-void Reactor::schedule(const std::optional<std::chrono::milliseconds> timeout) {
+void Reactor::schedule(const optional<chrono::milliseconds> timeout) {
   bool is_shutdown = false;
   // NOTE: the polling behavior is to handle the case where a fiber yields but
   // there are currently no other runnable fibers and no uring events have occurred
@@ -291,7 +291,7 @@ void Reactor::schedule(const std::optional<std::chrono::milliseconds> timeout) {
              runnable_.size(), "] entries");
       dbgOut("current fiber [", active_fbr_id, "] is yielding [",
              active_fbr_fcb.body.is_fiber_yielding,
-             "] is handling uring envent [",
+             "] is handling uring event [",
              active_fbr_fcb.body.is_fiber_handling_event, "]");
 
       if (active_fbr_fcb.body.is_fiber_yielding) {
@@ -355,7 +355,7 @@ void Reactor::schedule(const std::optional<std::chrono::milliseconds> timeout) {
       // TODO(bd) support awaiting a batch of events
       // poll or wait for uring events
       auto event = [&] {
-        std::optional<Duration> uring_timeout = nullopt;
+        optional<Duration> uring_timeout = nullopt;
         if (timeout && !is_polling) { *uring_timeout = from(*timeout); }
         return uring_->awaitEvent(uring_timeout);
       }();
@@ -443,7 +443,6 @@ void Reactor::schedule(const std::optional<std::chrono::milliseconds> timeout) {
 
           // enqueue the new fiber control block on the runnable queue
           runnable_.enqueue(fcb);
-
           resetNotifier();
         }
       }

--- a/experimental/reactor/reactor.cpp
+++ b/experimental/reactor/reactor.cpp
@@ -231,7 +231,7 @@ void Reactor::start() {
 
 void Reactor::shutdown() { detail::sendNotification(post_src_, kShutdownCmd); }
 
-void Reactor::post(FiberFcn&& fcn) {
+void Reactor::execute(FiberFcn&& fcn) {
   // TODO(bd) try to come up with a better way to do this
   auto lambda_ptr = make_unique<FiberFcn>(std::move(fcn));
 

--- a/experimental/reactor/reactor.h
+++ b/experimental/reactor/reactor.h
@@ -72,7 +72,7 @@ public:
   /**
    * send work to be performed by a new fiber in the reactor
    */
-  void post(FiberFcn&& fcn);
+  void execute(FiberFcn&& fcn);
 
 private:
   static constexpr size_t kMaxFibers = FiberCtrl::kMaxFibers;

--- a/experimental/reactor/reactor.h
+++ b/experimental/reactor/reactor.h
@@ -80,7 +80,7 @@ private:
 
   using OptMillisec = std::optional<std::chrono::milliseconds>;
   using OptStrView = std::optional<std::string_view>;
-  using WorkerFcn = std::function<void(void)>;
+  using WorkerFcn = Fiber::WorkerFcn;
 
   // TODO(bd) maybe experiment with boost thread pool once it is
   // building correctly
@@ -158,6 +158,12 @@ private:
   void execute(Fcn&& fcn) {
     thread_pool_.execute(std::move(fcn));
   }
+
+  /**
+   * notify a fiber that thread pool computation data is ready for
+   * consumption
+   */
+  void notifyFbr(FiberId id);
 
   std::atomic<bool> is_shutdown_ = false;
   FiberCtrl fiber_ctrl_;

--- a/experimental/reactor/test_uring.cpp
+++ b/experimental/reactor/test_uring.cpp
@@ -57,8 +57,8 @@ TEST(UringTests, SmokeTest) {
   EXPECT_EQ(unsafe(user_data), unsafe(event.getUserData()));
 
   const auto diff = end_ts - begin_ts;
-  chrono::microseconds chrono_diff = from(diff);
-  EXPECT_TRUE(chrono_diff.count() >= 10 * kMicroSecPerMillisec)
+  Duration duration_diff = from(diff);
+  EXPECT_TRUE(duration_diff.count() >= 10 * kNanosecPerMillisec)
     << "event duration was less than expected timeout";
 }
 

--- a/include/jmg/future.h
+++ b/include/jmg/future.h
@@ -214,4 +214,15 @@ private:
   std::promise<void> prm_;
 };
 
+/**
+ * construct a promise/future pair that communicate a value of a
+ * specific type
+ */
+template<typename T>
+auto makeCommunicator() {
+  auto sndr = Promise<T>();
+  auto rcvr = sndr.get_future();
+  return make_tuple(std::move(sndr), std::move(rcvr));
+}
+
 } // namespace jmg

--- a/include/jmg/ip_endpoint.h
+++ b/include/jmg/ip_endpoint.h
@@ -50,6 +50,8 @@ JMG_DEFINE_RUNTIME_EXCEPTION(MalformedIpAddress);
 /**
  * representation of an internet protocol endpoint, used for convenience and
  * improved type safety
+ *
+ * TODO(bd) handle IPv6
  */
 class IpEndpoint {
   static void makeSysAddr(const char* addr,
@@ -57,6 +59,9 @@ class IpEndpoint {
                           sockaddr_in& sys_addr);
 
 public:
+  /**
+   * construct an IpEndpoint from a string address and port
+   */
   template<NullTerminatedStringT T>
   IpEndpoint(const T& addr, Port port) {
     if constexpr (CStyleStringT<T>) {
@@ -67,6 +72,11 @@ public:
       makeSysAddr(addr.data(), unsafe(port), sys_addr_);
     }
   }
+
+  /**
+   * construct an IpEndpoint from a struct sockaddr
+   */
+  IpEndpoint(const sockaddr& addr, std::optional<size_t> sz = std::nullopt);
 
   const sockaddr_in& addr() const { return sys_addr_; }
 

--- a/include/jmg/preprocessor.h
+++ b/include/jmg/preprocessor.h
@@ -158,12 +158,18 @@
     }                                                          \
   } while (0)
 
-#define JMG_SYSFCN_PTR_RETURN(func, ...)      \
-  []() {                                      \
-    auto* ptr = (func);                       \
-    JMG_ENFORCE(static_cast<bool>(ptr), ...); \
-    return ptr;                               \
-  }()
+/**
+ * call a POSIX-style system function that returns a valid pointer on
+ * success and nullptr on failure (with errno set), and throw an
+ * exception of type std::system_error if it fails
+ *
+ * in this case, the returned pointer is ignored because the function
+ * is presumed to have written to a buffer supplied by the caller
+ */
+#define JMG_SYSFCN_PTR_RETURN(func, ...)                  \
+  do {                                                    \
+    if (!(func)) { JMG_THROW_SYSTEM_ERROR(__VA_ARGS__); } \
+  } while (0)
 
 ////////////////////////////////////////////////////////////////////////////////
 // helper macros for testing

--- a/include/jmg/preprocessor.h
+++ b/include/jmg/preprocessor.h
@@ -91,11 +91,11 @@
  *
  * @todo use basename of filename?
  */
-#define JMG_THROW_EXCEPTION(ExceptionType, ...)                         \
+#define JMG_THROW_EXCEPTION(exception_type, ...)                        \
   do {                                                                  \
     const auto err_msg = absl::StrCat("'", __VA_ARGS__, "' on line ",   \
                                       __LINE__, " of file ", __FILE__); \
-    throw ExceptionType(err_msg);                                       \
+    throw exception_type(err_msg);                                      \
   } while (0)
 
 /**

--- a/include/jmg/types.h
+++ b/include/jmg/types.h
@@ -187,6 +187,10 @@ public:
   c_string_view() = default;
   c_string_view(const char* str) : std::string_view(str) {}
   c_string_view(const std::string& str) : std::string_view(str) {}
+  // NOTE: allowing construction from another c_string_view simplifies
+  // generic cases
+  c_string_view(const c_string_view& str)
+    : std::string_view(str.data(), str.size()) {}
   const char* c_str() const { return data(); }
 };
 

--- a/include/jmg/types.h
+++ b/include/jmg/types.h
@@ -185,12 +185,11 @@ class c_string_view : public std::string_view {
 
 public:
   c_string_view() = default;
-  c_string_view(const char* str) : std::string_view(str) {}
-  c_string_view(const std::string& str) : std::string_view(str) {}
+  c_string_view(const char* str) : Base(str) {}
+  c_string_view(const std::string& str) : Base(str) {}
   // NOTE: allowing construction from another c_string_view simplifies
   // generic cases
-  c_string_view(const c_string_view& str)
-    : std::string_view(str.data(), str.size()) {}
+  c_string_view(const c_string_view& str) : Base(str.data(), str.size()) {}
   const char* c_str() const { return data(); }
 };
 

--- a/include/jmg/types.h
+++ b/include/jmg/types.h
@@ -124,8 +124,7 @@ using OrderedSet = absl::btree_set<Ts...>;
 // time point/duration/zone
 ////////////////////////////////////////////////////////////////////////////////
 
-// TODO(bd) use std::chrono::nanoseconds instead of absl::Time
-using TimePoint = absl::Time;
+using TimePoint = std::chrono::sys_time<std::chrono::nanoseconds>;
 using TimeZone = absl::TimeZone;
 using Duration = std::chrono::nanoseconds;
 
@@ -169,7 +168,9 @@ inline TimeZone getTimeZone(const TimeZoneName tz_name) {
   return rslt;
 }
 
-inline TimePoint getCurrentTime() { return absl::Now(); }
+inline TimePoint getCurrentTime() {
+  return std::chrono::time_point_cast<Duration>(std::chrono::system_clock::now());
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 // strings

--- a/include/jmg/types.h
+++ b/include/jmg/types.h
@@ -127,8 +127,7 @@ using OrderedSet = absl::btree_set<Ts...>;
 // TODO(bd) use std::chrono::nanoseconds instead of absl::Time
 using TimePoint = absl::Time;
 using TimeZone = absl::TimeZone;
-// TODO(bd) use std::chrono::nanoseconds instead of absl::Duration
-using Duration = absl::Duration;
+using Duration = std::chrono::nanoseconds;
 
 #if defined(JMG_SAFETYPE_ALIAS_TEMPLATE_WORKS)
 using TimePointFmt = SafeType<std::string_view, SafeType>;

--- a/include/jmg/types.h
+++ b/include/jmg/types.h
@@ -127,7 +127,7 @@ using OrderedSet = absl::btree_set<Ts...>;
 // TODO(bd) use std::chrono::nanoseconds instead of absl::Time
 using TimePoint = absl::Time;
 using TimeZone = absl::TimeZone;
-// TODO(bd) use std::chrono duration instead of absl::Duration
+// TODO(bd) use std::chrono::nanoseconds instead of absl::Duration
 using Duration = absl::Duration;
 
 #if defined(JMG_SAFETYPE_ALIAS_TEMPLATE_WORKS)

--- a/include/jmg/util.h
+++ b/include/jmg/util.h
@@ -35,7 +35,6 @@
  * general purpose utilities
  */
 
-#include <future>
 #include <optional>
 #include <ranges>
 #include <tuple>

--- a/src/ip_endpoint.cpp
+++ b/src/ip_endpoint.cpp
@@ -38,6 +38,8 @@
 
 #include "jmg/preprocessor.h"
 
+using namespace std;
+
 namespace jmg
 {
 
@@ -53,6 +55,15 @@ void IpEndpoint::makeSysAddr(const char* addr,
   JMG_SYSTEM(inet_pton(AF_INET, addr, &(sys_addr.sin_addr)),
              "converting IP address to binary");
   sys_addr.sin_port = htons(port);
+}
+
+IpEndpoint::IpEndpoint(const sockaddr& addr, const optional<size_t> sz) {
+  JMG_ENFORCE(AF_INET == addr.sa_family, "address family type [",
+              addr.sa_family, "] is not currently supported");
+  JMG_ENFORCE(!sz || (sz >= sizeof(sys_addr_)), "provided size [", *sz,
+              "] is too small, must be at least [", sizeof(sys_addr_), "]");
+  memset(&sys_addr_, 0, sizeof(sys_addr_));
+  memcpy(&sys_addr_, &addr, sizeof(sys_addr_));
 }
 
 } // namespace jmg

--- a/test/test_conversion.cpp
+++ b/test/test_conversion.cpp
@@ -64,7 +64,8 @@ TEST(ConversionTests, TestConversionRelatedConcepts) {
   // StdChronoDurationT
   EXPECT_TRUE(StdChronoDurationT<std::chrono::nanoseconds>);
   EXPECT_TRUE(StdChronoDurationT<std::chrono::seconds>);
-  EXPECT_FALSE(StdChronoDurationT<Duration>);
+  EXPECT_TRUE(StdChronoDurationT<Duration>);
+  EXPECT_FALSE(StdChronoDurationT<absl::Duration>);
   EXPECT_FALSE(StdChronoDurationT<int>);
 }
 
@@ -266,7 +267,7 @@ TEST(ConversionTests, TestTimePointFromChronoTimePoint) {
 ////////////////////
 // conversions between various time durations
 
-const auto kDuration = absl::Seconds(42);
+const Duration kDuration = from(std::chrono::seconds(42));
 
 TEST(ConversionTests, TestDurationFromChronoDuration) {
   Duration actual = from(42s);
@@ -274,10 +275,9 @@ TEST(ConversionTests, TestDurationFromChronoDuration) {
   EXPECT_EQ(expected, actual);
 }
 
-TEST(ConversionTests, TestChronoDurationFromDuration) {
-  std::chrono::seconds actual = from(kDuration);
-  const auto expected = 42s;
-  EXPECT_EQ(expected, actual);
+TEST(ConversionTests, TestAbslDurationFromDuration) {
+  absl::Duration actual = from(kDuration);
+  EXPECT_EQ(kDuration.count(), absl::ToInt64Nanoseconds(actual));
 }
 
 TEST(ConversionTests, TestChronoDurationFromChronoDuration) {
@@ -298,6 +298,6 @@ TEST(ConversionTests, TestUringDurationFromDuration) {
 
 TEST(ConversionTests, TestDurationFromUringDuration) {
   const UringDuration uring_duration = {.tv_sec = 42, .tv_nsec = 5};
-  const Duration duration = from(uring_duration);
-  EXPECT_EQ(absl::Seconds(42) + absl::Nanoseconds(5), duration);
+  const Duration actual = from(uring_duration);
+  EXPECT_EQ(std::chrono::seconds(42) + std::chrono::nanoseconds(5), actual);
 }

--- a/test/test_conversion.cpp
+++ b/test/test_conversion.cpp
@@ -44,8 +44,6 @@ using namespace std;
 using namespace std::string_literals;
 using namespace std::chrono_literals;
 
-using ChronoTimePoint = std::chrono::time_point<std::chrono::system_clock>;
-
 TEST(ConversionTests, TestConversionRelatedConcepts) {
   // TimePointT
   EXPECT_TRUE(TimePointT<TimePoint>);
@@ -214,14 +212,9 @@ TEST(ConversionTests, TestPosixTimeFromTimePoint) {
   EXPECT_EQ(expected, actual);
 }
 
-TEST(ConversionTests, TestChronoTimePointFromTimePoint) {
-  ChronoTimePoint chrono_tp = from(kTimePoint);
-  const auto actual =
-    EpochSeconds(std::chrono::duration_cast<std::chrono::seconds>(
-                   chrono_tp.time_since_epoch())
-                   .count());
-  const auto expected = kEpochSeconds;
-  EXPECT_EQ(expected, actual);
+TEST(ConversionTests, TestAbslTimeFromTimePoint) {
+  absl::Time absl_tp = from(kTimePoint);
+  EXPECT_EQ(absl::ToUnixNanos(absl_tp), kTimePoint.time_since_epoch().count());
 }
 
 ////////////////////
@@ -256,10 +249,9 @@ TEST(ConversionTests, TestTimePointFromPosixTime) {
   EXPECT_EQ(expected, actual);
 }
 
-TEST(ConversionTests, TestTimePointFromChronoTimePoint) {
-  const auto chrono_tp =
-    ChronoTimePoint(std::chrono::seconds(kTimePointSeconds));
-  TimePoint actual = from(chrono_tp);
+TEST(ConversionTests, TestTimePointFromAbslTime) {
+  absl::Time absl_tp = absl::FromUnixSeconds(kTimePointSeconds);
+  TimePoint actual = from(absl_tp);
   const auto expected = kTimePoint;
   EXPECT_EQ(expected, actual);
 }


### PR DESCRIPTION
originally planned to do this using c-ares by  calling into it from fibers and hooking its callbacks into the uring functionality, but this ran into 2 problems:

1. c-ares can also read files and it uses old-school libc functions like `fopen` to do this work, which would result in fibers being blocked.
2. It doesn't work correctly out of the box on my Ubuntu desktop due to being only partially NSS compatible.

As a result, I took the expedient path and paired the new `fiber::compute` member function with a call to `getaddrinfo` and was able to get something working. Maybe I'll revisit at some point but seems like the problem of looking up addresses via DNS is much harder than one would expect.